### PR TITLE
feat: Merge notebook gerador e script SQL da tabela usuario (develop → main)

### DIFF
--- a/sql/scriptCriacao.sql
+++ b/sql/scriptCriacao.sql
@@ -1,0 +1,14 @@
+-- Criação da Tabela usuario
+CREATE TABLE usuario (
+  id SERIAL PRIMARY KEY,
+  nome_completo VARCHAR(30) NOT NULL,
+  endereco_email VARCHAR(320) NOT NULL UNIQUE,
+  senha VARCHAR(64) NOT NULL,
+  telefone VARCHAR(25) NOT NULL,
+  empresa VARCHAR(50) DEFAULT 'Empresa Não Informada',
+  foto VARCHAR(255),
+  
+  -- Restrições CHECK
+  CHECK (LENGTH(senha) >= 8),
+  CHECK (LENGTH(telefone) BETWEEN 8 AND 15)
+);

--- a/sql/scriptDataLoad.sql
+++ b/sql/scriptDataLoad.sql
@@ -1,0 +1,22 @@
+-- Inserção de dados na tabela usuario
+INSERT INTO usuario (nome_completo, endereco_email, senha, telefone, empresa, foto)
+VALUES('Mariah Aparecida', 'mariah.aparecida@gmail.com', '6skh6PTc', '+55 71 8764-7593', 'da Paz Carvalho S/A', '/explicabo/sit.jpg'),
+('Clara das Neves', 'clara.das.neves@gmail.com', 'rUR43GIv%7m', '+55 41 1578 1565', 'Novaes Mendes - ME', '/facilis/quasi.jpg'),
+('Yan Albuquerque', 'yan.albuquerque@yahoo.com', 'vq7hDBAudJj_g', '+55 31 6097 5351', 'Nunes Câmara S.A.', '/quisquam/dicta.jpg'),
+('Ayla Barros', 'ayla.barros@icloud.com', 'S3drwgrhvWCCq', '(051) 8714 8418', 'Nogueira', '/sed/enim.jpg'),
+('Laura Macedo', 'laura.macedo@icloud.com', 'Un5mD<XQ1', '+55 31 9659 3423', 'Andrade Pimenta e Filhos', '/pariatur/facilis.jpg'),
+('Caio Rocha', 'caio.rocha@gmail.com', '@0Ef)R4qM*X', '+55 81 2018 6848', 'Cunha Rocha - EI', '/repellendus/nihil.jpg'),
+('Rael Monteiro', 'rael.monteiro@hotmail.com', 'k6P6GSB<kM7%', '11 1591 7953', 'Almeida Siqueira Ltda.', '/voluptatibus/cum.jpg'),
+('Marcelo Vieira', 'marcelo.vieira@hotmail.com', '9GeD<O-%a4', '+55 (041) 5601-2309', 'Alves S/A', '/eaque/tempora.jpg'),
+('Bárbara Gonçalves', 'barbara.goncalves@outlook.com', '8Awma44-7NiW', '+55 31 5109 0321', 'Costela', '/veritatis/assumenda.jpg'),
+('Yago Lima', 'yago.lima@outlook.com', 'l7P8Oayb_&#', '0900-141-3145', 'Cirino', '/provident/assumenda.jpg'),
+('Ana Cecília Peixoto', 'ana.cecilia.peixoto@icloud.com', 'e&+gLf77jKQ', '+55 41 6345 7923', 'Viana e Filhos', '/dolorem/dolore.jpg'),
+('Dr. Dante Peixoto', 'dr.dante.peixoto@icloud.com', '-_723EZC(ItebQ', '(031) 2076-9845', 'Ribeiro', '/dolor/explicabo.jpg'),
+('Alice Marques', 'alice.marques@outlook.com', 'a3efczNvLP4', '+55 21 5084 2375', 'Rocha', '/rerum/magnam.jpg'),
+('Caroline Silva', 'caroline.silva@outlook.com', 'sKFhYBF%eYXe50i', '(041) 6610 9352', 'Câmara Porto - ME', '/voluptatum/minus.jpg'),
+('Maria Vitória Andrade', 'maria.vitoria.andrade@hotmail.com', 'PkoJ&f!$hYP', '71 9602 7142', 'Moura', '/ratione/placeat.jpg'),
+('Agatha Andrade', 'agatha.andrade@gmail.com', '_$mLqEeD>', '11 5470-6381', 'Albuquerque Guerra e Filhos', '/ipsam/nesciunt.jpg'),
+('Heitor Albuquerque', 'heitor.albuquerque@icloud.com', 'v259YLoqe5eydK)', '+55 (011) 8913 1934', 'Sales', '/consequuntur/ducimus.jpg'),
+('Maria Laura Pires', 'maria.laura.pires@outlook.com', 'eN$ff%F+RS', '+55 21 0471 4285', 'Cassiano Ltda.', '/animi/ad.jpg'),
+('Gustavo Rodrigues', 'gustavo.rodrigues@gmail.com', 'GSO_p4sEZ', '+55 71 8559-0977', 'Freitas', '/dolorum/quidem.jpg'),
+('Marcos Vinicius Pastor', 'marcos.vinicius.pastor@icloud.com', 'y6fJ<<fqu_&&Cm#', '(021) 0224 5551', 'Vasconcelos', '/amet/sit.jpg');

--- a/utils/geradorUsuario.ipynb
+++ b/utils/geradorUsuario.ipynb
@@ -1,0 +1,262 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Notebook para o gerador de script DataLoad da tabela usuário\n",
+    "\n",
+    "Esse código gera dados fictícios para inserir na tabela `usuário` do banco, usando Python e Faker para simular registros realistas.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Caso não esteja instalado, é necessário executar esse comando:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# !pip install faker --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Importações necessárias\n",
+    "import random as rd \n",
+    "import faker  # Módulo que gera dados falsos mas realistas"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instanciação do objeto"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "O código abaixo cria um gerador de dados falsos com configuração brasileira (pt_BR)\n",
+    "Faker é uma classe do módulo faker, e 'fake' é um objeto dessa classe que usamos pra gerar os dados"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fake = faker.Faker('pt_BR')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Guardando a semente\n",
+    "Guardar a semente faz com que os dados gerados sejam sempre os mesmos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "faker.Faker.seed(0)\n",
+    "rd.seed(42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Funções\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Função para remover os acentos do nome \n",
+    "Essa função remove os acentos do nome para gerar um email sem acentos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def remover_acentos(texto):\n",
+    "    acentos = {\n",
+    "        'á': 'a', 'à': 'a', 'ã': 'a', 'â': 'a',\n",
+    "        'é': 'e', 'ê': 'e',\n",
+    "        'í': 'i',\n",
+    "        'ó': 'o', 'õ': 'o', 'ô': 'o',\n",
+    "        'ú': 'u',\n",
+    "        'ç': 'c',\n",
+    "        'Á': 'a', 'À': 'a', 'Ã': 'a', 'Â': 'a',\n",
+    "        'É': 'e', 'Ê': 'e',\n",
+    "        'Í': 'i',\n",
+    "        'Ó': 'o', 'Õ': 'o', 'Ô': 'o',\n",
+    "        'Ú': 'u',\n",
+    "        'Ç': 'c'\n",
+    "    }\n",
+    "    resultado = \"\"\n",
+    "    for char in texto:\n",
+    "        if char in acentos:\n",
+    "            resultado += acentos[char]\n",
+    "        elif char.isalpha() or char == ' ':\n",
+    "            resultado += char\n",
+    "    return resultado\n",
+    "\n",
+    "        "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Função para gerar emails a partir de um nome como base"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def gerar_email(nome):\n",
+    "    nome_base = remover_acentos(nome).replace(\" \",\".\").lower() # Troca espaço por ponto pra ficar tipo nome.sobrenome\n",
+    "    dominios = [\"@gmail.com\",\"@hotmail.com\",\"@icloud.com\",\"@yahoo.com\",\"@outlook.com\"]\n",
+    "    email = nome_base + rd.choice(dominios)  # Essa função escolhe um item aleatório da sequência, nesse caso Escolhe um domínio aleatório da lista e junta com o nome_base\n",
+    "    return email"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Função para gerar senha"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def gerar_senha():\n",
+    "    digitos = \"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!@#$%&*()_+=-><\"\n",
+    "    tamanho = rd.randint(8,15) \n",
+    "    senha_lista = rd.choices(digitos,k=tamanho)  #Essa função escolhe um dígito repetidamente e vai guardando em uma lista\n",
+    "    #   Esse for junta os caracteres da lista numa string só, formando a senha\n",
+    "    senha = \"\"\n",
+    "    for c in senha_lista:\n",
+    "        senha += c\n",
+    "    return senha"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Gerando 20 registros com dados falsos e imprimindo no formato SQL"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INSERT INTO usuario (nome_completo, endereco_email, senha, telefone, empresa, foto)\n",
+      "VALUES('Mariah Aparecida', 'mariah.aparecida@gmail.com', '6skh6PTc', '+55 71 8764-7593', 'da Paz Carvalho S/A', '/explicabo/sit.jpg'),\n",
+      "('Clara das Neves', 'clara.das.neves@gmail.com', 'rUR43GIv%7m', '+55 41 1578 1565', 'Novaes Mendes - ME', '/facilis/quasi.jpg'),\n",
+      "('Yan Albuquerque', 'yan.albuquerque@yahoo.com', 'vq7hDBAudJj_g', '+55 31 6097 5351', 'Nunes Câmara S.A.', '/quisquam/dicta.jpg'),\n",
+      "('Ayla Barros', 'ayla.barros@icloud.com', 'S3drwgrhvWCCq', '(051) 8714 8418', 'Nogueira', '/sed/enim.jpg'),\n",
+      "('Laura Macedo', 'laura.macedo@icloud.com', 'Un5mD<XQ1', '+55 31 9659 3423', 'Andrade Pimenta e Filhos', '/pariatur/facilis.jpg'),\n",
+      "('Caio Rocha', 'caio.rocha@gmail.com', '@0Ef)R4qM*X', '+55 81 2018 6848', 'Cunha Rocha - EI', '/repellendus/nihil.jpg'),\n",
+      "('Rael Monteiro', 'rael.monteiro@hotmail.com', 'k6P6GSB<kM7%', '11 1591 7953', 'Almeida Siqueira Ltda.', '/voluptatibus/cum.jpg'),\n",
+      "('Marcelo Vieira', 'marcelo.vieira@hotmail.com', '9GeD<O-%a4', '+55 (041) 5601-2309', 'Alves S/A', '/eaque/tempora.jpg'),\n",
+      "('Bárbara Gonçalves', 'barbara.goncalves@outlook.com', '8Awma44-7NiW', '+55 31 5109 0321', 'Costela', '/veritatis/assumenda.jpg'),\n",
+      "('Yago Lima', 'yago.lima@outlook.com', 'l7P8Oayb_&#', '0900-141-3145', 'Cirino', '/provident/assumenda.jpg'),\n",
+      "('Ana Cecília Peixoto', 'ana.cecilia.peixoto@icloud.com', 'e&+gLf77jKQ', '+55 41 6345 7923', 'Viana e Filhos', '/dolorem/dolore.jpg'),\n",
+      "('Dr. Dante Peixoto', 'dr.dante.peixoto@icloud.com', '-_723EZC(ItebQ', '(031) 2076-9845', 'Ribeiro', '/dolor/explicabo.jpg'),\n",
+      "('Alice Marques', 'alice.marques@outlook.com', 'a3efczNvLP4', '+55 21 5084 2375', 'Rocha', '/rerum/magnam.jpg'),\n",
+      "('Caroline Silva', 'caroline.silva@outlook.com', 'sKFhYBF%eYXe50i', '(041) 6610 9352', 'Câmara Porto - ME', '/voluptatum/minus.jpg'),\n",
+      "('Maria Vitória Andrade', 'maria.vitoria.andrade@hotmail.com', 'PkoJ&f!$hYP', '71 9602 7142', 'Moura', '/ratione/placeat.jpg'),\n",
+      "('Agatha Andrade', 'agatha.andrade@gmail.com', '_$mLqEeD>', '11 5470-6381', 'Albuquerque Guerra e Filhos', '/ipsam/nesciunt.jpg'),\n",
+      "('Heitor Albuquerque', 'heitor.albuquerque@icloud.com', 'v259YLoqe5eydK)', '+55 (011) 8913 1934', 'Sales', '/consequuntur/ducimus.jpg'),\n",
+      "('Maria Laura Pires', 'maria.laura.pires@outlook.com', 'eN$ff%F+RS', '+55 21 0471 4285', 'Cassiano Ltda.', '/animi/ad.jpg'),\n",
+      "('Gustavo Rodrigues', 'gustavo.rodrigues@gmail.com', 'GSO_p4sEZ', '+55 71 8559-0977', 'Freitas', '/dolorum/quidem.jpg'),\n",
+      "('Marcos Vinicius Pastor', 'marcos.vinicius.pastor@icloud.com', 'y6fJ<<fqu_&&Cm#', '(021) 0224 5551', 'Vasconcelos', '/amet/sit.jpg');\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Começa a imprimir o comando SQL de inserção, \n",
+    "# com os nomes das colunas da tabela 'usuario'\n",
+    "print(\"INSERT INTO usuario (nome_completo, endereco_email, senha, telefone, empresa, foto)\\nVALUES\",end=\"\")\n",
+    "\n",
+    "for i in range(20):\n",
+    "    nome_completo = fake.name()[:30] # Limita o nome a 30 caracteres\n",
+    "    endereco_email = gerar_email(nome_completo)\n",
+    "    senha = gerar_senha()\n",
+    "    telefone = fake.phone_number() \n",
+    "    empresa = fake.company()\n",
+    "    foto = fake.file_path(category=\"image\", extension=\"jpg\")\n",
+    "    # Imprime os valores formatados para inserir no banco\n",
+    "    if(i < 19):\n",
+    "        print(f\"('{nome_completo}', '{endereco_email}', '{senha}', '{telefone}', '{empresa}', '{foto}'),\")\n",
+    "    else:\n",
+    "        print(f\"('{nome_completo}', '{endereco_email}', '{senha}', '{telefone}', '{empresa}', '{foto}');\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
# 📌 Descrição

Este PR adiciona um notebook Python para geração automática de comandos SQL `INSERT INTO usuario` com dados fictícios.  
Os dados são simulados usando a biblioteca `Faker`, com suporte ao idioma português do Brasil, e incluem nome, email, senha, telefone, empresa e caminho de imagem.

Além disso, este PR inclui:
- Criação da tabela `usuario` em SQL com restrições de segurança (`CHECK`) para senha e telefone.
- Script de inserção (DataLoad) de 20 usuários gerados automaticamente no formato adequado para o banco de dados PostgreSQL.

# ✅ Checklist

- [x] Notebook funcional com Faker e random
- [x] Dados realistas respeitando limites da tabela
- [x] Scripts SQL com `CREATE TABLE` e `INSERT INTO`
- [x] Campos gerados respeitam os requisitos de tipo e tamanho
- [x] Código comentado e organizado para entendimento
- [x] Output pronto para uso em ambiente PostgreSQL
